### PR TITLE
Specify namespace when using boost::placeholders.

### DIFF
--- a/lib/src/ptb/code/player.cpp
+++ b/lib/src/ptb/code/player.cpp
@@ -3828,7 +3828,7 @@ void ptb::player::create_invincible_star()
     ( 1, 0, 0.4,
       boost::bind
       ( &bear::visual::bitmap_rendering_attributes::set_opacity,
-        &(s->get_rendering_attributes()), _1 ), 
+        &(s->get_rendering_attributes()), boost::placeholders::_1 ),
       &claw::tween::easing_linear::ease_in );
 
   bear::tweener_item* t = new bear::tweener_item(tweener, s, true);

--- a/lib/src/ptb/item/castle/code/catapult.cpp
+++ b/lib/src/ptb/item/castle/code/catapult.cpp
@@ -253,7 +253,8 @@ void ptb::catapult::start_throw()
      (m_arm_angle, -1.57+m_stop_angle, 0.1,
        boost::bind
        ( &catapult::on_arm_angle_update,
-	 this, _1 ), &claw::tween::easing_linear::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_linear::ease_out ) );
   m_arm_angle_tweener.insert
     (claw::tween::single_tweener
      (m_arm_angle, 0, 0.5,
@@ -282,7 +283,8 @@ void ptb::catapult::cancel()
      (m_arm_angle, m_arm_angle-0.2, 0.05,
        boost::bind
        ( &catapult::on_arm_angle_update,
-	 this, _1 ), &claw::tween::easing_linear::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_linear::ease_out ) );
   m_arm_angle_tweener.insert
     (claw::tween::single_tweener
      (m_arm_angle, 0, 0.5,
@@ -351,25 +353,29 @@ void ptb::catapult::create_stop_angle_tweener()
      (0, -s_initial_stop_angle, 0.3,
        boost::bind
        ( &catapult::on_stop_angle_update,
-	 this, _1 ), &claw::tween::easing_cubic::ease_in ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_cubic::ease_in ) );
   m_stop_angle_tweener.insert
     (claw::tween::single_tweener
      (-s_initial_stop_angle, 0, 0.3,
        boost::bind
        ( &catapult::on_stop_angle_update,
-	 this, _1 ), &claw::tween::easing_cubic::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_cubic::ease_out ) );
   m_stop_angle_tweener.insert
     (claw::tween::single_tweener
      (0, s_initial_stop_angle, 0.3,
        boost::bind
        ( &catapult::on_stop_angle_update,
-	 this, _1 ), &claw::tween::easing_cubic::ease_in ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_cubic::ease_in ) );
   m_stop_angle_tweener.insert
     (claw::tween::single_tweener
      (s_initial_stop_angle, 0, 0.3,
        boost::bind
        ( &catapult::on_stop_angle_update,
-	 this, _1 ), &claw::tween::easing_cubic::ease_out ) ); 
+	     this, boost::placeholders::_1 ),
+       &claw::tween::easing_cubic::ease_out ) );
 } // catapult::create_stop_angle_tweener()
 
 /*----------------------------------------------------------------------------*/
@@ -384,13 +390,15 @@ void ptb::catapult::create_arm_angle_tweener()
      (m_arm_angle, s_minimal_arm_angle, 1,
        boost::bind
        ( &catapult::on_arm_angle_update,
-	 this, _1 ), &claw::tween::easing_cubic::ease_in ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_cubic::ease_in ) );
   m_arm_angle_tweener.insert
     (claw::tween::single_tweener
      (s_minimal_arm_angle, s_maximal_arm_angle, 1,
        boost::bind
        ( &catapult::on_arm_angle_update,
-	 this, _1 ), &claw::tween::easing_cubic::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_cubic::ease_out ) );
 } // catapult::create_arm_angle_tweener()
 
 /*----------------------------------------------------------------------------*/
@@ -405,13 +413,14 @@ void ptb::catapult::init_angle()
      (m_arm_angle, s_maximal_arm_angle, 0.5,
        boost::bind
        ( &catapult::on_arm_angle_update,
-	 this, _1 ), &claw::tween::easing_linear::ease_in ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_linear::ease_in ) );
    m_arm_angle_tweener.insert
     (claw::tween::single_tweener
      (m_arm_angle, s_initial_arm_angle, 1,
        boost::bind
        ( &catapult::start_idle,
-	 this ), &claw::tween::easing_linear::ease_in ) );
+         this ), &claw::tween::easing_linear::ease_in ) );
 
   m_stop_angle_tweener.clear();
   m_stop_angle_tweener.insert
@@ -419,7 +428,8 @@ void ptb::catapult::init_angle()
      (m_stop_angle, 0, 0.5,
        boost::bind
        ( &catapult::on_stop_angle_update,
-	 this, _1 ), &claw::tween::easing_linear::ease_in ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_linear::ease_in ) );
 } // catapult::init_angle()
 
 /*----------------------------------------------------------------------------*/

--- a/lib/src/ptb/item/code/invincibility_effect.cpp
+++ b/lib/src/ptb/item/code/invincibility_effect.cpp
@@ -74,7 +74,7 @@ void ptb::invincibility_effect::create_star()
     ( 1, 0, 0.4,
       boost::bind
       ( &bear::visual::bitmap_rendering_attributes::set_opacity,
-        &(s->get_rendering_attributes()), _1 ), 
+        &(s->get_rendering_attributes()), boost::placeholders::_1 ),
       &claw::tween::easing_linear::ease_in );
 
   bear::tweener_item* t = new bear::tweener_item(tweener, s, true);

--- a/lib/src/ptb/item/code/power_effect.cpp
+++ b/lib/src/ptb/item/code/power_effect.cpp
@@ -79,17 +79,20 @@ void ptb::power_effect::set_player_index( unsigned int i )
   connect
     ( bear::engine::game::get_instance().listen_bool_variable_change
       ( game_variables::get_air_power_variable_name(i),
-        boost::bind( &power_effect::on_air_power_changed, this, _1) ) );
+        boost::bind( &power_effect::on_air_power_changed, this,
+                     boost::placeholders::_1) ) );
 
   connect
     ( bear::engine::game::get_instance().listen_bool_variable_change
       ( game_variables::get_fire_power_variable_name(i),
-        boost::bind( &power_effect::on_fire_power_changed, this, _1) ) );
+        boost::bind( &power_effect::on_fire_power_changed, this,
+                     boost::placeholders::_1) ) );
 
   connect
     ( bear::engine::game::get_instance().listen_bool_variable_change
       ( game_variables::get_water_power_variable_name(i),
-        boost::bind( &power_effect::on_water_power_changed, this, _1) ) );
+        boost::bind( &power_effect::on_water_power_changed, this,
+                     boost::placeholders::_1) ) );
 } // power_effect::set_player_index()
 
 /*----------------------------------------------------------------------------*/

--- a/lib/src/ptb/item_brick/impl/item_with_single_player_action_reader.tpp
+++ b/lib/src/ptb/item_brick/impl/item_with_single_player_action_reader.tpp
@@ -52,7 +52,7 @@ void ptb::item_with_single_player_action_reader<Base>::on_enters_layer()
       m_client_observer.subscribe<player_action_message>
 	( boost::bind
 	  ( &item_with_single_player_action_reader<Base>::on_message,
-	    this, _1 ) );
+	    this, boost::placeholders::_1 ) );
     }
 } // item_with_single_player_action_reader::on_enters_layer()
 

--- a/lib/src/ptb/layer/code/status_layer.cpp
+++ b/lib/src/ptb/layer/code/status_layer.cpp
@@ -209,7 +209,8 @@ void ptb::status_layer::player_status::progress_notification
              (notification.height()+s_margin, -1, 0.5,
               boost::bind
               ( &player_status::on_notification_position_update,
-                this, _1 ), &claw::tween::easing_back::ease_in ) );
+                this, boost::placeholders::_1 ),
+              &claw::tween::easing_back::ease_in ) );
       }
     }
 } // player_status::progress_notification
@@ -234,14 +235,16 @@ void ptb::status_layer::player_status::create_notification()
        (0, notification.height()+s_margin, 0.5,
         boost::bind
         (&player_status::on_notification_position_update,
-         this, _1 ), &claw::tween::easing_back::ease_out ) );
+         this, boost::placeholders::_1 ),
+        &claw::tween::easing_back::ease_out ) );
       
    m_notification_tweener.insert
       (claw::tween::single_tweener
        (notification.height()+s_margin, notification.height()+s_margin,1,
         boost::bind
         (&player_status::on_notification_position_update,
-         this, _1 ), &claw::tween::easing_linear::ease_out ) );     
+         this, boost::placeholders::_1 ),
+        &claw::tween::easing_linear::ease_out ) );
 } // player_status::create_notification()
 
 /*----------------------------------------------------------------------------*/

--- a/lib/src/ptb/layer/code/windows_layer.cpp
+++ b/lib/src/ptb/layer/code/windows_layer.cpp
@@ -390,7 +390,7 @@ void ptb::windows_layer::apply_show_effect( window_item wnd )
 
   const claw::tween::single_tweener t
     ( get_size().y, m_ref_bottom[wnd], s_effect_duration,
-      boost::bind( &frame::set_bottom, wnd, _1 ),
+      boost::bind( &frame::set_bottom, wnd, boost::placeholders::_1 ),
       &claw::tween::easing_back::ease_out );
 
   m_tweener.insert(t);
@@ -415,7 +415,8 @@ void ptb::windows_layer::apply_hide_effect( window_item wnd, bool d )
   // updating the position of the window once it was deleted by the end of the
   // hide effect.
   claw::tween::single_tweener t
-    ( wnd->top(), 0, s_effect_duration, boost::bind( &frame::set_top, wnd, _1 ),
+    ( wnd->top(), 0, s_effect_duration, boost::bind( &frame::set_top, wnd,
+                                                     boost::placeholders::_1 ),
       &claw::tween::easing_quad::ease_out );
 
   if ( d )

--- a/lib/src/ptb/layer/status/code/corrupting_bonus_component.cpp
+++ b/lib/src/ptb/layer/status/code/corrupting_bonus_component.cpp
@@ -175,7 +175,7 @@ void ptb::corrupting_bonus_component::init_signals()
       ( game_variables::get_corrupting_bonus_count_variable_name(),
         boost::bind
         (&ptb::corrupting_bonus_component::on_corrupting_bonus_updated,
-         this, _1) ) );
+         this, boost::placeholders::_1) ) );
 } // corrupting_bonus_component::init_signals()
 
 /*----------------------------------------------------------------------------*/
@@ -239,21 +239,24 @@ void ptb::corrupting_bonus_component::move()
       (get_position().y, get_active_position().y, 0.3,
        boost::bind
        ( &ptb::status_component::on_y_position_update,
-         this, _1 ), &claw::tween::easing_back::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
   
   tween.insert
 	( claw::tween::single_tweener
 	  (get_active_position().y, get_active_position().y, 1,
 	   boost::bind
 	   ( &ptb::status_component::on_y_position_update,
-	     this, _1 ), &claw::tween::easing_back::ease_in ) );
+	     this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_in ) );
       
   tween.insert
     ( claw::tween::single_tweener
       (get_active_position().y, get_inactive_position().y, 0.5,
        boost::bind
        ( &ptb::status_component::on_y_position_update,
-	 this, _1 ), &claw::tween::easing_back::ease_in ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_in ) );
 
   add_tweener( tween );
 } // corrupting_bonus_component::move()
@@ -271,21 +274,24 @@ void ptb::corrupting_bonus_component::change_scale()
       (1, 1, 0.3,
        boost::bind
        (&ptb::corrupting_bonus_component::on_corrupting_bonus_scale_update,
-	this, _1 ), &claw::tween::easing_back::ease_out ) );
+        this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
   
   tween.insert
     ( claw::tween::single_tweener
       (1, 1.5, 0.3,
        boost::bind
        (&ptb::corrupting_bonus_component::on_corrupting_bonus_scale_update,
-	this, _1 ), &claw::tween::easing_back::ease_out ) );
+        this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
   
   tween.insert
     ( claw::tween::single_tweener
       (1.5, 1, 0.3,
        boost::bind
        (&ptb::corrupting_bonus_component::on_corrupting_bonus_scale_update,
-	this, _1 ), &claw::tween::easing_back::ease_in ) );
+        this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_in ) );
   
   add_tweener( tween );
 } // corrupting_bonus_component::change_scale()

--- a/lib/src/ptb/layer/status/code/energy_component.cpp
+++ b/lib/src/ptb/layer/status/code/energy_component.cpp
@@ -118,19 +118,21 @@ void ptb::energy_component::init_signals()
   add_signal
     ( get_player().get_signals().energy_added.connect
       ( boost::bind
-        (&ptb::energy_component::on_energy_added, this, _1) ) );
+        (&ptb::energy_component::on_energy_added, this,
+         boost::placeholders::_1) ) );
   
   add_signal
     ( get_player().get_signals().energy_removed.connect
       ( boost::bind
-        (&ptb::energy_component::on_energy_removed, this, _1) ) );
+        (&ptb::energy_component::on_energy_removed, this,
+         boost::placeholders::_1) ) );
 
   add_signal
     ( bear::engine::game::get_instance().listen_double_variable_change
       ( game_variables::get_max_energy_variable_name(get_player().get_index()),
         boost::bind
         (&ptb::energy_component::on_max_energy_added,
-         this, _1) ) );
+         this, boost::placeholders::_1) ) );
 } // energy_component::init_signals()
 
 /*----------------------------------------------------------------------------*/
@@ -146,7 +148,8 @@ void ptb::energy_component::on_energy_changed()
       (get_position().y, get_active_position().y, 0.3,
        boost::bind
        ( &ptb::status_component::on_y_position_update,
-         this, _1 ), &claw::tween::easing_back::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
 
   if ( ! m_energy.is_critical() )
     {
@@ -155,14 +158,16 @@ void ptb::energy_component::on_energy_changed()
 	  (get_active_position().y, get_active_position().y, 1,
 	   boost::bind
 	   ( &ptb::status_component::on_y_position_update,
-	     this, _1 ), &claw::tween::easing_back::ease_in ) );
+	     this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_in ) );
       
       tween.insert
 	( claw::tween::single_tweener
 	  (get_active_position().y, get_inactive_position().y, 0.5,
 	   boost::bind
 	   ( &ptb::status_component::on_y_position_update,
-	     this, _1 ), &claw::tween::easing_back::ease_in ) );
+	     this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_in ) );
     }
 
   add_tweener( tween );
@@ -203,7 +208,8 @@ void ptb::energy_component::on_max_energy_added(double e)
       (m_energy.length(), e, 1,
        boost::bind
        ( &ptb::energy_component::on_max_energy_length_update,
-         this, _1 ), &claw::tween::easing_elastic::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_elastic::ease_out ) );
 } // energy_component::on_max_energy_added()
 
 /*----------------------------------------------------------------------------*/

--- a/lib/src/ptb/layer/status/code/floating_bonus.cpp
+++ b/lib/src/ptb/layer/status/code/floating_bonus.cpp
@@ -110,7 +110,7 @@ void ptb::floating_bonus::set_position
     ( init_position.x, end_position.x, 1.0,
       boost::bind
       (&floating_bonus::on_x_position_update,
-       this, _1 ), &claw::tween::easing_back::ease_in );
+       this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in );
   
   m_tweeners.insert(tween_x);
 
@@ -118,7 +118,7 @@ void ptb::floating_bonus::set_position
     ( init_position.y, end_position.y, 1.0,
       boost::bind
       (&floating_bonus::on_y_position_update,
-       this, _1 ), &claw::tween::easing_back::ease_in );
+       this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in );
   
   m_tweeners.insert(tween_y);
 } // floating_bonus::set_position()

--- a/lib/src/ptb/layer/status/code/floating_corrupting_bonus.cpp
+++ b/lib/src/ptb/layer/status/code/floating_corrupting_bonus.cpp
@@ -88,7 +88,7 @@ void ptb::floating_corrupting_bonus::set_position
     ( init_position.x, end_position.x, 0.5,
       boost::bind
       (&floating_corrupting_bonus::on_x_position_update,
-       this, _1 ), &easing_back_large::ease_in );
+       this, boost::placeholders::_1 ), &easing_back_large::ease_in );
   
        m_tweeners.insert(tween_x);
 
@@ -96,7 +96,7 @@ void ptb::floating_corrupting_bonus::set_position
     ( init_position.y, end_position.y, 0.5,
       boost::bind
       (&floating_corrupting_bonus::on_y_position_update,
-       this, _1 ), &easing_back_large::ease_in );
+       this, boost::placeholders::_1 ), &easing_back_large::ease_in );
   
   m_tweeners.insert(tween_y);
 } // floating_corrupting_bonus::set_position()

--- a/lib/src/ptb/layer/status/code/gauge_component.cpp
+++ b/lib/src/ptb/layer/status/code/gauge_component.cpp
@@ -102,7 +102,8 @@ void ptb::gauge_component::on_enters_zone()
       (get_position().x, get_active_position().x, 1,
        boost::bind
        ( &ptb::gauge_component::on_x_position_update,
-	 this, _1 ), &claw::tween::easing_elastic::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_elastic::ease_out ) );
 } // gauge_component::on_enters_zone()
 
 /*----------------------------------------------------------------------------*/
@@ -116,13 +117,15 @@ void ptb::gauge_component::on_leaves_zone()
       (get_position().x, get_position().x, 0.5,
        boost::bind
        ( &ptb::gauge_component::on_x_position_update,
-	 this, _1 ), &claw::tween::easing_linear::ease_in_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_linear::ease_in_out ) );
 
   tween.insert( claw::tween::single_tweener
       (get_position().x, get_inactive_position().x, 1,
        boost::bind
        ( &ptb::gauge_component::on_x_position_update,
-	 this, _1 ), &claw::tween::easing_linear::ease_in_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_linear::ease_in_out ) );
 
   add_tweener( tween );
 } // gauge_component::on_leaves_zone()

--- a/lib/src/ptb/layer/status/code/honeypots_component.cpp
+++ b/lib/src/ptb/layer/status/code/honeypots_component.cpp
@@ -127,21 +127,22 @@ void ptb::honeypots_component::on_count_change()
       (get_position().y, get_active_position().y, 0.5,
        boost::bind
        ( &ptb::status_component::on_y_position_update,
-         this, _1 ), &claw::tween::easing_back::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
 
   tween.insert
     ( claw::tween::single_tweener
       (get_active_position().y, get_active_position().y, 2,
        boost::bind
        ( &ptb::status_component::on_y_position_update,
-	 this, _1 ), &claw::tween::easing_back::ease_in ) );
+	 this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in ) );
   
   tween.insert
     ( claw::tween::single_tweener
       (get_active_position().y, get_inactive_position().y, 0.5,
        boost::bind
        ( &ptb::status_component::on_y_position_update,
-	 this, _1 ), &claw::tween::easing_back::ease_in ) );
+	 this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in ) );
   
   add_tweener( tween );
 } // honeypots_component::on_count_change()

--- a/lib/src/ptb/layer/status/code/lives_component.cpp
+++ b/lib/src/ptb/layer/status/code/lives_component.cpp
@@ -120,7 +120,8 @@ void ptb::lives_component::init_signals()
       ( game_variables::get_lives_count_variable_name
 	(get_player().get_index()),
         boost::bind
-        (&ptb::lives_component::on_lives_changed,this, _1) ) );
+        (&ptb::lives_component::on_lives_changed,this,
+         boost::placeholders::_1) ) );
 } // lives_component::init_signals()
 
 /*----------------------------------------------------------------------------*/
@@ -159,19 +160,22 @@ void ptb::lives_component::on_lives_changed(unsigned int s)
       (1, 1, 0.5,
        boost::bind
        ( &ptb::lives_component::on_lives_scale_update,
-         this, _1 ), &claw::tween::easing_back::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
   tween.insert
     ( claw::tween::single_tweener
       (1, 1.5, 0.5,
        boost::bind
        ( &ptb::lives_component::on_lives_scale_update,
-         this, _1 ), &claw::tween::easing_back::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
   tween.insert
     ( claw::tween::single_tweener
       (1.5, 1, 0.5,
        boost::bind
        ( &ptb::lives_component::on_lives_scale_update,
-         this, _1 ), &claw::tween::easing_back::ease_in ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_in ) );
 
   add_tweener( tween );
 
@@ -182,21 +186,22 @@ void ptb::lives_component::on_lives_changed(unsigned int s)
       (get_position().x, get_active_position().x, 0.3,
        boost::bind
        ( &ptb::status_component::on_x_position_update,
-         this, _1 ), &claw::tween::easing_back::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
 
   tween2.insert
     ( claw::tween::single_tweener
       (get_active_position().x, get_active_position().x, 2,
        boost::bind
        ( &ptb::status_component::on_x_position_update,
-	 this, _1 ), &claw::tween::easing_back::ease_in ) );
+	 this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in ) );
   
   tween2.insert
     ( claw::tween::single_tweener
       (get_active_position().x, get_inactive_position().x, 0.5,
        boost::bind
        ( &ptb::status_component::on_x_position_update,
-	 this, _1 ), &claw::tween::easing_back::ease_in ) );
+	 this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in ) );
   
   add_tweener( tween2 );
 } // lives_component::on_lives_changed()

--- a/lib/src/ptb/layer/status/code/score_component.cpp
+++ b/lib/src/ptb/layer/status/code/score_component.cpp
@@ -109,7 +109,7 @@ void ptb::score_component::init_signals()
       ( game_variables::get_score_variable_name(get_player().get_index()),
         boost::bind
         (&ptb::score_component::on_score_changed,
-         this, _1) ) );
+         this, boost::placeholders::_1) ) );
 } // score_component::init_signals()
 
 /*----------------------------------------------------------------------------*/
@@ -133,21 +133,22 @@ void ptb::score_component::on_score_changed(unsigned int s)
       (get_position().x, get_active_position().x, 0.3,
        boost::bind
        ( &ptb::status_component::on_x_position_update,
-         this, _1 ), &claw::tween::easing_back::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
 
   tween.insert
     ( claw::tween::single_tweener
       (get_active_position().x, get_active_position().x, 1,
        boost::bind
        ( &ptb::status_component::on_x_position_update,
-	 this, _1 ), &claw::tween::easing_back::ease_in ) );
+	 this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in ) );
   
   tween.insert
     ( claw::tween::single_tweener
       (get_active_position().x, get_inactive_position().x, 0.5,
        boost::bind
        ( &ptb::status_component::on_x_position_update,
-	 this, _1 ), &claw::tween::easing_back::ease_in ) );
+	 this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in ) );
   
   add_tweener( tween );
 } // score_component::on_score_changed()

--- a/lib/src/ptb/layer/status/code/throwable_item_component.cpp
+++ b/lib/src/ptb/layer/status/code/throwable_item_component.cpp
@@ -175,13 +175,13 @@ void ptb::throwable_item_component::init_signals()
     ( get_player().get_throwable_items().throwable_item_changed.connect
       ( boost::bind
         (&ptb::throwable_item_component::on_throwable_item_changed,
-         this, _1) ) );
+         this, boost::placeholders::_1) ) );
   
   add_signal
     ( get_player().get_throwable_items().throwable_item_stock_changed.connect
       ( boost::bind
         (&ptb::throwable_item_component::on_throwable_item_stock_changed,
-         this, _1) ) );
+         this, boost::placeholders::_1) ) );
 
   add_signal
     ( get_player().get_throwable_items().throwable_item_no_stock.connect
@@ -192,26 +192,30 @@ void ptb::throwable_item_component::init_signals()
     ( bear::engine::game::get_instance().listen_bool_variable_change
       ( game_variables::get_air_power_variable_name(get_player().get_index()),
         boost::bind
-        ( &throwable_item_component::on_power_changed, this, _1, "air") ) );
+        ( &throwable_item_component::on_power_changed, this,
+          boost::placeholders::_1, "air") ) );
 
   add_signal
     ( bear::engine::game::get_instance().listen_bool_variable_change
       ( game_variables::get_fire_power_variable_name(get_player().get_index()),
         boost::bind
-        ( &throwable_item_component::on_power_changed, this, _1, "fire") ) );
+        ( &throwable_item_component::on_power_changed, this,
+          boost::placeholders::_1, "fire") ) );
 
   add_signal
     ( bear::engine::game::get_instance().listen_bool_variable_change
       ( game_variables::get_water_power_variable_name(get_player().get_index()),
         boost::bind
-        ( &throwable_item_component::on_power_changed, this, _1, "water") ) );
+        ( &throwable_item_component::on_power_changed, this,
+          boost::placeholders::_1, "water") ) );
 
   add_signal
     ( bear::engine::game::get_instance().listen_uint_variable_change
       ( game_variables::get_stones_count_variable_name
         (get_player().get_index()),
         boost::bind
-        ( &throwable_item_component::on_stones_stock_changed, this, _1) ) );
+        ( &throwable_item_component::on_stones_stock_changed, this,
+          boost::placeholders::_1) ) );
 } // throwable_item_component::init_signals()
 
 /*----------------------------------------------------------------------------*/
@@ -324,21 +328,22 @@ void ptb::throwable_item_component::on_throwable_item_changed()
       (get_position().x, get_active_position().x, 0.3,
        boost::bind
        ( &ptb::status_component::on_x_position_update,
-         this, _1 ), &claw::tween::easing_back::ease_out ) );
+         this, boost::placeholders::_1 ),
+       &claw::tween::easing_back::ease_out ) );
 
   tween.insert
     ( claw::tween::single_tweener
       (get_active_position().x, get_active_position().x, 1,
        boost::bind
        ( &ptb::status_component::on_x_position_update,
-	 this, _1 ), &claw::tween::easing_back::ease_in ) );
+	 this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in ) );
   
   tween.insert
     ( claw::tween::single_tweener
       (get_active_position().x, get_inactive_position().x, 0.5,
        boost::bind
        ( &ptb::status_component::on_x_position_update,
-	 this, _1 ), &claw::tween::easing_back::ease_in ) );
+	 this, boost::placeholders::_1 ), &claw::tween::easing_back::ease_in ) );
 
   add_tweener( tween ); 
 } // throwable_item_component::on_throwable_item_changed()


### PR DESCRIPTION
This fixes compilation problems when building against boost 1.74 where
placeholders are no longer imported into the global namespace by
default.